### PR TITLE
Swallow pre-beep CRs

### DIFF
--- a/potato.sh
+++ b/potato.sh
@@ -59,6 +59,7 @@ do
 	! $MUTE && aplay /usr/share/sounds/speech-dispatcher/test.wav &>/dev/null
 
 	if $INTERACTIVE; then
+		read -d '' -t 0.001
 		echo -e "\a"
 		echo "Work over"
 		read
@@ -71,6 +72,7 @@ do
 	done
 	! $MUTE && aplay /usr/share/sounds/speech-dispatcher/test.wav &>/dev/null
 	if $INTERACTIVE; then
+		read -d '' -t 0.001
 		echo -e "\a"
 		echo "Pause over"
 		read


### PR DESCRIPTION
This effectively makes potato flush its STDIN before alerting the user that his interval is done. This is to avoid the effects of pressing enter during an interval, i.e. staring the next interval immediately.